### PR TITLE
修复点击"下载音频文件"失败报错

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,7 +360,7 @@ function download_base_info() {
 }
 
 // 下载喵 “下载音频文件”按键 
-function download2(id, index) {
+function download2() {
     let time = document.getElementById("download_interval_input").value;
 
     if(isNumber(time)) {
@@ -371,7 +371,7 @@ function download2(id, index) {
         show_alert("给ye填数字啊，kora");
     }
 
-    for(let i = index; i < id.length; i++) {
+    for(let i = 0; i < id.length; i++) {
         setTimeout(() => {
             mp3play(id[i], i)
         }, time * i);


### PR DESCRIPTION
### 操作：
1. 导入id文件之后。
2. 点击“下载音频文件”按钮。
### 现象
1. 音频未下载。
2. 控制台报错：
>Uncaught TypeError: Cannot read properties of undefined (reading 'length')
>    at download2 (index.js:374:31)
>    at HTMLButtonElement.onclick ((index):160:39)


### 错误原因：
`download2`函数调用时`id`传参为空。

### 解决方式：
使用全局`id`参数。


